### PR TITLE
Remove xtend dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var extend = require('xtend/immutable');
-
 // Public API
 module.exports = cartesian;
 
@@ -67,7 +65,7 @@ function cartesian(list)
  */
 function clone(obj)
 {
-  return Array.isArray(obj) ? [].concat(obj) : extend(obj);
+  return Array.isArray(obj) ? [].concat(obj) : Object.assign({}, obj);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "eslint": "^3.11.1",
     "istanbul": "^0.4.5",
     "pre-commit": "^1.1.3"
-  },
-  "dependencies": {
-    "xtend": "^4.0.1"
   }
 }


### PR DESCRIPTION
Simple libraries like a cartesian should not have any dependencies.
The standard function 'Object.assign' can replace
'extend' function from xtend.